### PR TITLE
support for oneOf and allOf added

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
 <title>Demo</title>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 </head>
 
 <body>

--- a/examples/index.js
+++ b/examples/index.js
@@ -10,14 +10,27 @@ const reducer = combineReducers({
   form: formReducer
 })
 
-var schema = {
-    "title":"my form",
-    "properties":
-        {
-            "name": { "type":"string","title":"Model", "default": "Ziummmm"},
-            "description": { "type":"string", "title": "Description", "format": "textarea" }
-        },
-        "required":["name"]};
+var schema ={
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": { "type": "string" },
+        "city":           { "type": "string" },
+        "state":          { "type": "string" }
+      },
+      "required": ["street_address", "city", "state"]
+    }
+  },
+
+  "allOf": [
+    { "$ref": "#/definitions/address" },
+    { "properties": {
+        "type": { "enum": [ "residential", "business" ] }
+      }
+    }
+  ]
+};
 
 const store = (window.devToolsExtension ? window.devToolsExtension()(createStore) : createStore)(reducer)
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "ajv": "^4.11.3",
     "classnames": "^2.2.5",
+    "deepmerge": "^1.4.4",
     "lodash": "^4.10.0",
     "prop-types": "^15.5.10",
     "redux-form": "^6.0.2"

--- a/src/compileSchema.js
+++ b/src/compileSchema.js
@@ -13,7 +13,7 @@ function compileSchema(schema, root) {
         for (let i in schema) {
             if (schema.hasOwnProperty(i)) {
                 if (i === '$ref') {
-                    newSchema = resolveRef(schema[i], root)
+                    newSchema = compileSchema(resolveRef(schema[i], root), root)
                 } else {
                     newSchema[i] = compileSchema(schema[i], root)
                 }
@@ -39,6 +39,7 @@ function resolveRef(uri, schema) {
     const tip = tokens.reduce((obj, token) => (
         obj[token]
     ), schema)
+
     return tip
 }
 

--- a/src/renderField.js
+++ b/src/renderField.js
@@ -7,10 +7,17 @@ const guessWidget = (fieldSchema) => {
     else if (fieldSchema.hasOwnProperty('enum')) {
         return 'choice'
     }
+    else if(fieldSchema.hasOwnProperty('allOf')) {
+        return 'allOf'
+    }
+    else if(fieldSchema.hasOwnProperty('oneOf')) {
+        return 'oneOf'
+    }
     return fieldSchema.type || 'object'
 }
 
 const renderField = (fieldSchema, fieldName, theme, prefix = '', context = {}, required = false) => {
+    
     const widget = guessWidget(fieldSchema)
 
     if (!theme[widget]) {

--- a/src/themes/bootstrap3/allOfWidget.js
+++ b/src/themes/bootstrap3/allOfWidget.js
@@ -2,52 +2,50 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Field } from 'redux-form'
-import _ from 'lodash'
+import renderField from '../../renderField'
+import deepmerge from 'deepmerge'
 
-const renderSelect = field => {
+const renderInput = field => {
     const className = classNames([
         'form-group',
         { 'has-error' : field.meta.touched && field.meta.error }
     ])
-    const options = field.schema.enum
-
-    const enum_titles = field.schema.enum_titles || field.schema.options? field.schema.options.enum_titles: {}
-    const optionNames = enum_titles || options
-
-    const selectOptions = _.zipObject(options, optionNames)
+    const schema = mergeSchema(field.schema)
+    
     return (
         <div className={className}>
-            <label className="control-label" htmlFor={'field-'+field.name}>{field.label}</label>
-            <select {...field.input} className="form-control" id={'field-'+field.name} required={field.required} multiple={field.multiple}>
-                { !field.required && !field.multiple && <option key={''} value={''}>{field.placeholder}</option> }
-                { _.map(selectOptions, (name, value) => {
-                    return <option key={value} value={value}>{name}</option>
-                })}
-            </select>
-
             {field.meta.touched && field.meta.error && <span className="help-block">{field.meta.error}</span>}
             {field.description && <span className="help-block">{field.description}</span>}
+            {renderField({ ...schema, showLabel : false }, field.fieldName, field.theme, field.fieldName+'.', field.context)}
         </div>
     )
 }
 
-const ChoiceWidget = props => {
+const mergeSchema = schema => {
+    let newSchema = deepmerge.all(schema.allOf)
+    newSchema = { ...schema, ...newSchema }
+    delete newSchema.allOf
+    return newSchema
+}
+
+const allOfWidget = props =>  {
     return (
         <Field
-            component={renderSelect}
+            component={renderInput}
             label={props.label}
             name={props.fieldName}
+            fieldName={props.fieldName}
             required={props.required}
             id={'field-'+props.fieldName}
             placeholder={props.schema.default}
             description={props.schema.description}
             schema={props.schema}
-            multiple={props.multiple}
+            theme={props.theme}
         />
     )
 }
 
-ChoiceWidget.propTypes = {
+allOfWidget.propTypes = {
     schema: PropTypes.object.isRequired,
     fieldName: PropTypes.string,
     label: PropTypes.string,
@@ -56,4 +54,4 @@ ChoiceWidget.propTypes = {
     required: PropTypes.bool,
 }
 
-export default ChoiceWidget
+export default allOfWidget

--- a/src/themes/bootstrap3/index.js
+++ b/src/themes/bootstrap3/index.js
@@ -18,6 +18,8 @@ import DateTimeWidget from './DateTimeWidget'
 import CompatibleDateWidget from './CompatibleDateWidget'
 import CompatibleDateTimeWidget from './CompatibleDateTimeWidget'
 import FileWidget from './FileWidget'
+import OneOfChoiceWidget from './oneOfChoiceWidget'
+import allOfWidget from './allOfWidget'
 
 export default {
     object: ObjectWidget,
@@ -41,4 +43,6 @@ export default {
     'compatible-date': CompatibleDateWidget,
     'compatible-datetime': CompatibleDateTimeWidget,
     file : FileWidget,
+    oneOf: OneOfChoiceWidget,
+    allOf: allOfWidget,
 }

--- a/src/themes/bootstrap3/oneOfChoiceWidget.js
+++ b/src/themes/bootstrap3/oneOfChoiceWidget.js
@@ -1,0 +1,79 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { Field } from 'redux-form'
+import renderField from '../../renderField'
+import _ from 'lodash'
+
+class renderSelect extends Component {
+    constructor(props) {
+        super(props)
+        this.state =  {
+            choice: ''
+        }
+    }
+    
+    render() {
+        const field = this.props
+        const className = classNames([
+            'form-group',
+            { 'has-error' : field.meta.touched && field.meta.error }
+        ])
+        const schema = field.schema
+        const options = schema.oneOf
+        const theme = field.theme
+        const context = field.context
+
+        return (
+            <div className={className}>
+                <label className="control-label" htmlFor={'field-'+field.fieldName}>{schema.title}</label>
+                <select className="form-control" onClick={(e)=> this.showItem(options[e.target.value], e.target.value, theme, field.fieldName, context)} id={'field-'+field.fieldName} required={field.required} multiple={false}>
+                    { !field.required && !field.multiple && <option key={''} value={''}>{field.placeholder}</option> }
+                    { _.map(options, item => {
+                        return <option key={options.indexOf(item)}  value={options.indexOf(item)}>{item.title}</option>
+                    })}
+                </select>
+                <div className="container">
+                    {
+                        this.state.choice
+                    }
+                </div>
+                { field.meta.touched && field.meta.error && <span className="help-block">{field.meta.error}</span> }
+                { field.description && <span className="help-block">{field.description}</span> }
+            </div>
+        )
+    }
+    showItem(item, idx, theme, name, context) {
+        this.setState({ choice: renderField({ ...item, showLabel : true }, idx.toString(), theme, name+'.', context) })
+    }
+}
+
+
+const OneOfChoiceWidget = props => {
+    return (
+        <Field
+            component={renderSelect}
+            label={props.label}
+            name={props.fieldName}
+            required={props.required}
+            id={'field-'+props.fieldName}
+            placeholder={props.schema.default}
+            description={props.schema.description}
+            schema={props.schema}
+            theme={props.theme}
+            context={props.context}
+            fieldName={props.fieldName}
+        />
+    )
+}
+
+OneOfChoiceWidget.propTypes = {
+    schema: PropTypes.object.isRequired,
+    fieldName: PropTypes.string,
+    label: PropTypes.string,
+    theme: PropTypes.object,
+    multiple: PropTypes.bool,
+    required: PropTypes.bool,
+}
+
+export default OneOfChoiceWidget

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -12,6 +12,7 @@ import SearchWidget from './SearchWidget'
 import UrlWidget from './UrlWidget'
 import ColorWidget from './ColorWidget'
 import ChoiceWidget from './ChoiceWidget'
+import OneOfChoiceWidget from './oneOfChoiceWidget'
 import DateWidget from './DateWidget'
 import TimeWidget from './TimeWidget'
 import DateTimeWidget from './DateTimeWidget'
@@ -36,5 +37,6 @@ export default {
     date: DateWidget,
     datetime: DateTimeWidget,
     time: TimeWidget,
+    OneOfChoiceWidget: OneOfChoiceWidget,
     'compatible-date': CompatibleDateWidget,
 }


### PR DESCRIPTION
This PR pertains to issue #10 ,
The following changes have been made

1. support for oneOF has been added. I have created a oneOFChoiceWidget, which is used to select which schema to use in case of a oneOf schema
2. support for allOf has been added too. I have added an allOf schema which is used to generate the schema for an allOF situation
3. I fixed an issue with the complile schema function. It could not compile nested $refs but that is fixed now.
4. added the two new widgets to the widgets index.js
5. added the widgets support by checking in the renderfield guessWidget method
6. added check of enum_titles inside options property for choiceWidget

@nacmartin Looking forward to get your reviews so as to get this code good enough for merging soon. any changes are welcome.