### PR TITLE
[oneOf] fixed issue with oneOf where values are added to data tree wrongly

### DIFF
--- a/src/renderField.js
+++ b/src/renderField.js
@@ -19,21 +19,24 @@ const renderField = (fieldSchema, fieldName, theme, prefix = '', context = {}, r
         fieldSchema = { ...fieldSchema, ...deepmerge.all(fieldSchema.allOf) }
         delete fieldSchema.allOf
     }
-
+    
     const widget = guessWidget(fieldSchema)
 
     if (!theme[widget]) {
         throw new Error('liform: ' + widget + ' is not defined in the theme')
     }
 
+    const newFieldName = prefix ? prefix + fieldName : fieldName
+
     return React.createElement(theme[widget], {
         key: fieldName,
-        fieldName: prefix ? prefix + fieldName : fieldName,
+        fieldName: widget == 'oneOf'? fieldName: newFieldName,
         label: fieldSchema.showLabel === false ? '' : fieldSchema.title || fieldName,
         required: required,
         schema: fieldSchema,
         theme,
         context,
+        prefix
     })
 }
 

--- a/src/themes/bootstrap3/ArrayWidget.js
+++ b/src/themes/bootstrap3/ArrayWidget.js
@@ -15,13 +15,13 @@ const renderArrayFields = (count, schema, theme, fieldName, remove, context, swa
                     
                     {(idx!=count-1 && count>1)?
                         <button className="btn btn-primary" onClick={(e)=>{
-                            e.preventDefault();
+                            e.preventDefault()
                             swap(idx, idx+1)
                         }}><span className="glyphicon glyphicon-arrow-down"></span></button>:''
                     }
                     {(idx!=0 && count>1)?
                         <button className="btn btn-primary" onClick={(e)=>{
-                            e.preventDefault();
+                            e.preventDefault()
                             swap(idx, idx-1)
                         }}><span className="glyphicon glyphicon-arrow-up"></span></button>:''
                     }

--- a/src/themes/bootstrap3/ArrayWidget.js
+++ b/src/themes/bootstrap3/ArrayWidget.js
@@ -5,16 +5,33 @@ import { FieldArray } from 'redux-form'
 import _ from 'lodash'
 import ChoiceWidget from './ChoiceWidget'
 
-const renderArrayFields = (count, schema, theme, fieldName, remove, context) => {
+const renderArrayFields = (count, schema, theme, fieldName, remove, context, swap) => {
     const prefix = fieldName + '.'
     if (count) {
         return _.times(count, (idx) => {
             return (
             <div key={idx}>
-                <button className="pull-right btn btn-danger" onClick={(e) => {
-                    e.preventDefault()
-                    remove(idx)
-                }}><span className="glyphicon glyphicon-trash"></span></button>
+                <div className="btn-group pull-right ">
+                    
+                    {(idx!=count-1 && count>1)?
+                        <button className="btn btn-primary" onClick={(e)=>{
+                            e.preventDefault();
+                            swap(idx, idx+1)
+                        }}><span className="glyphicon glyphicon-arrow-down"></span></button>:''
+                    }
+                    {(idx!=0 && count>1)?
+                        <button className="btn btn-primary" onClick={(e)=>{
+                            e.preventDefault();
+                            swap(idx, idx-1)
+                        }}><span className="glyphicon glyphicon-arrow-up"></span></button>:''
+                    }
+
+                    <button className="btn btn-danger" onClick={(e) => {
+                        e.preventDefault()
+                        remove(idx)
+                    }}><span className="glyphicon glyphicon-trash"></span></button>
+
+                </div>
                 {renderField({ ...schema, showLabel : false }, idx.toString(), theme, prefix, context)}
             </div>
             )
@@ -28,7 +45,7 @@ const renderInput = field => {
     return (
         <div className="arrayType form-group">
             <legend className="control-label" >{field.label}</legend>
-            { renderArrayFields(field.fields.length, field.schema.items, field.theme, field.fieldName, (idx) => field.fields.remove(idx), field.context) }
+            { renderArrayFields(field.fields.length, field.schema.items, field.theme, field.fieldName, (idx) => field.fields.remove(idx), field.context, (a, b) => {field.fields.swap(a,b)}) }
             <button type="button" className="pull-right btn btn-primary" onClick={() => field.fields.push({})}>Add</button>
             <div className="clearfix"/>
         </div>

--- a/src/themes/bootstrap3/oneOfChoiceWidget.js
+++ b/src/themes/bootstrap3/oneOfChoiceWidget.js
@@ -45,7 +45,7 @@ class OneOfChoiceWidget extends Component {
     renderOption() {
         const field = this.props
         const schema = field.schema.oneOf[this.state.choice]
-        return renderField(schema, field.name, field.theme, field.name, field.context)
+        return renderField(schema, field.fieldName, field.theme, field.prefix, field.context)
     }
 
     selectItem(e) {


### PR DESCRIPTION
This PR is meant to fix the issue added with the implementation of oneOf and allOf which i did earlier. 
When items are added to the array of a oneOf schema the information is not added to the tree correctly. it is rather added to the root of the data object instead of within the appropriate array. 

This has been handled in this PR

Also added buttons to help swap array members for arrays so as to enable re-positioning of values in an array