### PR TITLE
Update json schema - format is now widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var schema = {
     "properties":
         {
             "name": { "type":"string","title":"Model", "default": "Ziummmm"},
-            "description": { "type":"string", "title": "Description", "format": "textarea" }
+            "description": { "type":"string", "title": "Description", "widget": "textarea" }
         },
         "required":["name"]};
 


### PR DESCRIPTION
The code "format":"textarea" throws an error "Uncaught Error: unknown format "textarea" is used in schema at path "#/properties/description""