### PR TITLE
Add ability to custom the submit button

### DIFF
--- a/src/__tests__/createLiformSpec.spec.js
+++ b/src/__tests__/createLiformSpec.spec.js
@@ -22,6 +22,30 @@ describe("createLiform", () => {
     }
   };
 
+  it("should render the custom button", () => {
+    const Component = (
+      <FormFrame>
+        <Liform schema={schema}>
+          <button type="submit" className="btn, btn-primary" id="customBtn" />
+        </Liform>
+      </FormFrame>
+    );
+
+    const wrapper = render(Component);
+    expect(wrapper.find("#customBtn").length).toEqual(1);
+  });
+
+  it("should render the default button without custom", () => {
+    const Component = (
+      <FormFrame>
+        <Liform schema={schema} />
+      </FormFrame>
+    );
+
+    const wrapper = render(Component);
+    expect(wrapper.find("button.btn").length).toEqual(1);
+  });
+
   //const schemaWrong = {
   //    title: 'A schema',
   //    properties: {

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,17 @@ import { setError } from "./buildSyncValidation";
 import compileSchema from "./compileSchema";
 
 const BaseForm = props => {
-  const { schema, handleSubmit, theme, error, submitting, context } = props;
+  const { schema, handleSubmit, theme, error, submitting, context, children } = props;
   return (
     <form onSubmit={handleSubmit}>
       {renderField(schema, null, theme || DefaultTheme, "", context)}
       <div>{error && <strong>{error}</strong>}</div>
-      <button className="btn btn-primary" type="submit" disabled={submitting}>
-        Submit
-      </button>
+      {children ? 
+        children : 
+        <button className="btn btn-primary" type="submit" disabled={submitting}>
+          Submit
+        </button>
+      }
     </form>
   );
 };


### PR DESCRIPTION
* Enable us to custom the submit button with library like material-ui instead of plain bootstrap. pass the button as children for liform.

Example:
```js
<Liform schema={schema} onSubmit={showResult}>
  // custom button from material-ui
  // must have a button with type submit
  <RaisedButton type="submit" label="Submit" />
</Liform>
```