### PR TITLE
Expose buildSyncValidation and compileSchema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,5 +59,7 @@ export {
   renderField,
   processSubmitErrors,
   DefaultTheme,
-  setError
+  setError,
+  buildSyncValidation,
+  compileSchema,
 };


### PR DESCRIPTION
The `<Liform/>` component currently creates a new redux-form decorated `<FinalForm/>` on every render. This means that usage with a dynamic schema will cause unnecessary field registrations on every render. This can be avoided by exposing more utility functions that can be passed into a pre-existing redux-form decorated form component.