### PR TITLE
Update package.json to allow newer versions deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "prop-types": "^15.5.10",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-redux": "^5.0.6",
+    "react-redux": "^5.0.6 || ^6.0.0 || ^7.0.0",
     "redux": "^3.5.2",
-    "redux-form": "^7.2.0"
+    "redux-form": "^7.2.0 || ^8.0.0"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
Update to allow newer version of react-redux and react-form since from what I can see it's compatible (have run the test suite) and keeping the versions low creates problems, in particular where react-redux < 6 can't really coexist with versions > 6. 