### PR TITLE
fix choice and date selector default value

### DIFF
--- a/src/__tests__/themes.bootstrap3.ChoiceWidget.spec.js
+++ b/src/__tests__/themes.bootstrap3.ChoiceWidget.spec.js
@@ -27,7 +27,7 @@ describe("ChoiceWidget", () => {
     expect(wrapper.find("option").length).toEqual(3);
   });
 
-  it("required renders no extra field", () => {
+  it("required attr renders required field", () => {
     const schema = {
       title: "A schema",
       properties: {
@@ -37,6 +37,30 @@ describe("ChoiceWidget", () => {
         }
       },
       required: ["choice"]
+    };
+
+    const Component = (
+      <FormFrame>
+        <Liform schema={schema} />
+      </FormFrame>
+    );
+
+    const wrapper = render(Component);
+    expect(wrapper.find("select").length).toEqual(1);
+    expect(wrapper.find("option").length).toEqual(3);
+    expect(wrapper.find("select").prop('required')).toEqual(true);
+  });
+
+  it("default=false renders no extra field", () => {
+    const schema = {
+      title: "A schema",
+      properties: {
+        choice: {
+          default: false,
+          type: "string",
+          enum: ["foo", "bar"]
+        }
+      }
     };
 
     const Component = (

--- a/src/themes/bootstrap3/ChoiceWidget.js
+++ b/src/themes/bootstrap3/ChoiceWidget.js
@@ -25,8 +25,7 @@ const renderSelect = field => {
         required={field.required}
         multiple={field.multiple}
       >
-        {!field.required &&
-          !field.multiple && (
+        {false !== field.placeholder && (
             <option key={""} value={""}>
               {field.placeholder}
             </option>

--- a/src/themes/bootstrap3/DateSelector.js
+++ b/src/themes/bootstrap3/DateSelector.js
@@ -10,7 +10,7 @@ const DateSelector = props => {
       id={"props-" + props.name}
       required={props.required}
     >
-      {!props.required && (
+      {props.emptyOption && (
         <option key={""} value={""}>
           {props.emptyOption}
         </option>


### PR DESCRIPTION
**Problem**: Required fields make the placeholder (default value) disappear in select inputs.

**Solution**: In order to avoid select placeholder, set `placeholder` to `false`.
